### PR TITLE
upgrade codecov and checkout actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include = src/*
+omit =
+    src/pyplif_hippos/_version.py
+    tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-include = src/*
-omit =
-    src/pyplif_hippos/_version.py
-    tests/*

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        python -m pip install . -e --no-deps
+        python -m pip install -e . --no-deps
         pip freeze
 
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,23 +34,23 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-#    - uses: conda-incubator/setup-miniconda@v2
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#        environment-file: devtools/conda-envs/test_env.yaml
-#
-#        channels: conda-forge,defaults
-#
-#        activate-environment: test
-#        auto-update-conda: false
-#        auto-activate-base: false
-#        show-channel-urls: true
-
-    - name: install mamba
-      uses: mamba-org/provision-with-micromamba@main
+    - uses: conda-incubator/setup-miniconda@v2
       with:
-        environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
-        environment-name: python-${{ matrix.python-version }}-env
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        channels: conda-forge,defaults
+
+        activate-environment: test
+        auto-update-conda: false
+        auto-activate-base: false
+        show-channel-urls: true
+
+#    - name: install mamba
+#      uses: mamba-org/provision-with-micromamba@main
+#      with:
+#        environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
+#        environment-name: python-${{ matrix.python-version }}-env
 
     - name: Install package
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Additional info about the build
       shell: bash
@@ -64,8 +64,9 @@ jobs:
         pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage1.xml,./coverage2.xml
         flags: unittests
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        verbose: true

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -58,7 +58,7 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
+        micromamba list
 
 
     - name: Run tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -64,10 +64,9 @@ jobs:
     - name: Run tests
 
       # conda setup requires this special shell
-      shell: bash
-
+      shell: bash -l {0}
       run: |
-        pytest -v --cov=src --cov-config=setup.cfg --cov-report=xml --color=yes tests
+        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
+        pytest -p pytest_cov -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
+        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests/
+        pytest -v --cov=src --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov=pyplif_hippos --cov-report=xml --color=yes tests
+        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -58,7 +58,7 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        micromamba list
+        conda list
 
 
     - name: Run tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
+        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,22 +32,7 @@ jobs:
         df -h
         ulimit -a
 
-
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-#    - uses: conda-incubator/setup-miniconda@v2
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#        environment-file: devtools/conda-envs/test_env.yaml
-#
-#        channels: conda-forge,defaults
-#
-#        activate-environment: test
-#        auto-update-conda: false
-#        auto-activate-base: false
-#        show-channel-urls: true
-
-    - name: install mamba
-      uses: mamba-org/provision-with-micromamba@main
+    - uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
         environment-name: python-${{ matrix.python-version }}-env

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov=src --cov-report=xml --color=yes tests
+        pytest -v --cov=pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,31 +34,31 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-#    - name: install mamba
-#      uses: mamba-org/provision-with-micromamba@main
+#    - uses: conda-incubator/setup-miniconda@v2
 #      with:
-#        environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
-#        environment-name: python-${{ matrix.python-version }}-env
+#        python-version: ${{ matrix.python-version }}
+#        environment-file: devtools/conda-envs/test_env.yaml
+#
+#        channels: conda-forge,defaults
+#
+#        activate-environment: test
+#        auto-update-conda: false
+#        auto-activate-base: false
+#        show-channel-urls: true
+
+    - name: install mamba
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
+        environment-name: python-${{ matrix.python-version }}-env
 
     - name: Install package
 
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        python -m pip install . --no-deps
-        conda list
+        python -m pip install . -e --no-deps
+        pip freeze
 
 
     - name: Run tests
@@ -66,7 +66,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        pytest -p pytest_cov -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
+        pytest -v --cov=src/pyplif_hippos --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        python -m pip install . --no-deps --use-feature=in-tree-build
+        python -m pip install . --no-deps
         micromamba list
 
 
@@ -67,7 +67,8 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes
+        coverage run --source=src -m pytest -v && coverage xml
+#        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        coverage run --source=src -m pytest -v && coverage xml
+        coverage run -m pytest -v tests && coverage xml
 #        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes
 
     - name: CodeCov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,6 @@ jobs:
       shell: bash
 
       run: |
-#        coverage run -m pytest -v tests && coverage xml
         pytest -v --cov=src --cov-config=setup.cfg --cov-report=xml --color=yes tests
 
     - name: CodeCov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -64,11 +64,11 @@ jobs:
     - name: Run tests
 
       # conda setup requires this special shell
-      shell: bash -l {0}
+      shell: bash
 
       run: |
-        coverage run -m pytest -v tests && coverage xml
-#        pytest -v --cov-config=setup.cfg --cov=src/pyplif_hippos --cov-report=xml --color=yes
+#        coverage run -m pytest -v tests && coverage xml
+        pytest -v --cov=src --cov-config=setup.cfg --cov-report=xml --color=yes tests
 
     - name: CodeCov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,17 +34,23 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+#    - uses: conda-incubator/setup-miniconda@v2
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#        environment-file: devtools/conda-envs/test_env.yaml
+#
+#        channels: conda-forge,defaults
+#
+#        activate-environment: test
+#        auto-update-conda: false
+#        auto-activate-base: false
+#        show-channel-urls: true
+
+    - name: install mamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
+        environment-file: devtools/conda-envs/test_env-${{ matrix.python-version }}.yaml
+        environment-name: python-${{ matrix.python-version }}-env
 
     - name: Install package
 
@@ -66,7 +72,7 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage1.xml,./coverage2.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         verbose: true

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        python -m pip install . --no-deps
+        python -m pip install . --no-deps --use-feature=in-tree-build
         micromamba list
 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include MANIFEST.in
 include versioneer.py
 include setup.sh
 
-graft src
+graft src/pyplif_hippos
 global-exclude *.py[cod] __pycache__ *.so

--- a/devtools/conda-envs/test_env-3.7.yaml
+++ b/devtools/conda-envs/test_env-3.7.yaml
@@ -14,6 +14,7 @@ dependencies:
   
     # Testing
   - pytest
+  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/test_env-3.7.yaml
+++ b/devtools/conda-envs/test_env-3.7.yaml
@@ -1,0 +1,24 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+    # Base depends
+  - python=3.7
+  - pip
+
+    # Package dependencies
+  - numpy
+  - bitarray
+  - openbabel
+  
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+
+    # Pip-only installs
+  # - pip:
+  #   - openbabel-wheel
+  #   - codecov
+

--- a/devtools/conda-envs/test_env-3.7.yaml
+++ b/devtools/conda-envs/test_env-3.7.yaml
@@ -14,7 +14,6 @@ dependencies:
   
     # Testing
   - pytest
-  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/test_env-3.8.yaml
+++ b/devtools/conda-envs/test_env-3.8.yaml
@@ -1,0 +1,24 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+    # Base depends
+  - python=3.8
+  - pip
+
+    # Package dependencies
+  - numpy
+  - bitarray
+  - openbabel
+  
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+
+    # Pip-only installs
+  # - pip:
+  #   - openbabel-wheel
+  #   - codecov
+

--- a/devtools/conda-envs/test_env-3.8.yaml
+++ b/devtools/conda-envs/test_env-3.8.yaml
@@ -14,6 +14,7 @@ dependencies:
   
     # Testing
   - pytest
+  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/test_env-3.8.yaml
+++ b/devtools/conda-envs/test_env-3.8.yaml
@@ -14,7 +14,6 @@ dependencies:
   
     # Testing
   - pytest
-  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/test_env-3.9.yaml
+++ b/devtools/conda-envs/test_env-3.9.yaml
@@ -14,6 +14,7 @@ dependencies:
   
     # Testing
   - pytest
+  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/test_env-3.9.yaml
+++ b/devtools/conda-envs/test_env-3.9.yaml
@@ -1,0 +1,24 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+    # Base depends
+  - python=3.9
+  - pip
+
+    # Package dependencies
+  - numpy
+  - bitarray
+  - openbabel
+  
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+
+    # Pip-only installs
+  # - pip:
+  #   - openbabel-wheel
+  #   - codecov
+

--- a/devtools/conda-envs/test_env-3.9.yaml
+++ b/devtools/conda-envs/test_env-3.9.yaml
@@ -14,7 +14,6 @@ dependencies:
   
     # Testing
   - pytest
-  - pluggy=0.13.1
   - pytest-cov
   - codecov
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-line-length = 119
 VCS = git
 style = pep440
 versionfile_source = src/pyplif_hippos/_version.py
-versionfile_build = src/pyplif_hippos/_version.py
+versionfile_build = pyplif_hippos/_version.py
 tag_prefix = ''
 
 [aliases]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,8 @@
 
 [coverage:run]
 # .coveragerc to control coverage.py and pytest-cov
-include = */src/*
+include = src/*
 omit =
-    # Omit the tests
-    */tests/*
     # Omit generated versioneer
     src/pyplif_hippos/_version.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,8 @@ max-line-length = 119
 # Automatic version numbering scheme
 VCS = git
 style = pep440
-versionfile_source = pyplif_hippos/_version.py
-versionfile_build = pyplif_hippos/_version.py
+versionfile_source = src/pyplif_hippos/_version.py
+versionfile_build = src/pyplif_hippos/_version.py
 tag_prefix = ''
 
 [aliases]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 
 [coverage:run]
 # .coveragerc to control coverage.py and pytest-cov
+include = */src/*
 omit =
     # Omit the tests
     */tests/*


### PR DESCRIPTION
actions/checkout v1 -> v2
codecov/codecov-action v1 -> v2

If this work, continue migrating from miniconda to micromamba
conda-incubator/setup-miniconda -> mamba-org/provision-with-micromamba@main